### PR TITLE
Fix provider `dopper_token` schema field name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ terraform {
 }
 
 provider "doppler" {
-  token = "<YOUR DOPPLER TOKEN>"
+  doppler_token = "<YOUR DOPPLER TOKEN>"
 }
 
 data "doppler_secrets" "this" {}

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ The [Doppler](https://doppler.com) provider is used to interact with resources p
 
 ```hcl
 provider "doppler" {
-  token = "<YOUR DOPPLER TOKEN>"
+  doppler_token = "<YOUR DOPPLER TOKEN>"
 }
 ```
 


### PR DESCRIPTION
Closes #7 