### PR TITLE
Update README and examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ HOSTNAME=doppler.com
 NAMESPACE=core
 NAME=doppler
 BINARY=terraform-provider-${NAME}
-VERSION=dev
+# Only used for local development
+VERSION=0.0.1
 OS_ARCH=darwin_amd64
 
 default: install

--- a/README.md
+++ b/README.md
@@ -61,19 +61,21 @@ First, build and install the provider.
 make install
 ```
 
+Update `examples/main.tf` with the local development provider:
+
+```hcl
+terraform {
+  required_providers {
+    doppler = {
+      source  = "doppler.com/core/doppler"
+    }
+  }
+}
+```
+
 Then, run the following command to initialize the workspace and apply the sample configuration.
 
 ```shell
-terraform init && terraform apply
-```
-
-## Running the Example
-
-```shell
-# build and install
-make
 cd examples
-# init & apply
-terraform init
-terraform apply --auto-approve
+terraform init && terraform apply
 ```

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
-# Terraform Provider Doppler (Pre-Release)
-
-**This software is in pre-release and is not intended to be used in production.**
+# Terraform Provider Doppler
 
 The Doppler Terraform Provider allows you to interact with your [Doppler](https://doppler.com) secrets and configuration.
 
 # Usage
 
-```
+```hcl
 terraform {
   required_providers {
     doppler = {
-      version = "0.0.1"
+      # version = <latest version>
       source = "DopplerHQ/doppler"
     }
   }
@@ -32,10 +30,17 @@ output "max_workers" {
   value = tonumber(data.doppler_secrets.this.map.MAX_WORKERS)
 }
 
-# JSON values can be decoded direcly in Terraform
-# e.g. FEATURE_FLAGS = `{ "AUTOPILOT": true, "TOP_SPEED": 130 }`
-output "json_parsing_values" {
-  value = jsondecode(data.doppler_secrets.this.map.FEATURE_FLAGS)["TOP_SPEED"]
+resource "random_password" "db_password" {
+  length = 32
+  special = true
+}
+
+# Set secrets in Doppler
+resource "doppler_secret" "db_password" {
+  project = "backend"
+  config = "dev"
+  name = "DB_PASSWORD"
+  value = random_password.db_password.result
 }
 ```
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     doppler = {
-      version = "0.0.1"
-      source  = "DopplerHQ/doppler"
+      # version = <latest version>
+      source = "DopplerHQ/doppler"
     }
   }
 }
@@ -53,7 +53,7 @@ resource "random_password" "db_password" {
   special = true
 }
 
-resource "doppler_secret" "db_passsword" {
+resource "doppler_secret" "db_password" {
   project = "backend"
   config = "dev"
   name = "DB_PASSWORD"


### PR DESCRIPTION
We removed the "prerelease" language from the Terraform docs `docs/index.md` but I forgot to update the README. This also fixes some examples and clarifies the steps needed for local development.