### PR TITLE
Add example for multiple providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,55 @@ resource "doppler_service_token" "ci_github_token" {
 }
 ```
 
+## Referencing Secrets Using Multiple Access Tokens
+
+```
+terraform {
+  required_providers {
+    doppler = {
+      source = "DopplerHQ/doppler"
+      version = "1.0.0"
+    }
+  }
+}
+
+variable "doppler_token_dev" {
+  type = string
+  description = "A token to authenticate with Doppler for the dev config"
+}
+
+variable "doppler_token_prd" {
+  type = string
+  description = "A token to authenticate with Doppler for the prd config"
+}
+
+provider "doppler" {
+  doppler_token = var.doppler_token_dev
+  alias = "dev"
+}
+
+provider "doppler" {
+  doppler_token = var.doppler_token_prd
+  alias = "prd"
+}
+
+data "doppler_secrets" "dev" {
+  provider = doppler.dev
+}
+
+data "doppler_secrets" "prd" {
+  provider = doppler.prd
+}
+
+output "port-dev" {
+  value = nonsensitive(data.doppler_secrets.dev.map.PORT)
+}
+
+output "port-prd" {
+  value = nonsensitive(data.doppler_secrets.prd.map.PORT)
+}
+```
+
 # Terraform CDK
 
 Read the [Terraform CDK guide](https://docs.doppler.com/docs/terraform-cdk) to learn more about how to use this provider with Terraform CDK.

--- a/docs/data-sources/secrets.md
+++ b/docs/data-sources/secrets.md
@@ -11,6 +11,8 @@ Retrieve all secrets in the config.
 
 ## Example Usage
 
+Basic usage:
+
 ```terraform
 data "doppler_secrets" "this" {}
 
@@ -29,6 +31,46 @@ output "max_workers" {
 # e.g. FEATURE_FLAGS = `{ "AUTOPILOT": true, "TOP_SPEED": 130 }`
 output "json_parsing_values" {
   value = nonsensitive(jsondecode(data.doppler_secrets.this.map.FEATURE_FLAGS)["TOP_SPEED"])
+}
+```
+
+Referencing secrets from multiple projects:
+
+```terraform
+variable "doppler_token_dev" {
+  type = string
+  description = "A token to authenticate with Doppler for the dev config"
+}
+
+variable "doppler_token_prd" {
+  type = string
+  description = "A token to authenticate with Doppler for the prd config"
+}
+
+provider "doppler" {
+  doppler_token = var.doppler_token_dev
+  alias = "dev"
+}
+
+provider "doppler" {
+  doppler_token = var.doppler_token_prd
+  alias = "prd"
+}
+
+data "doppler_secrets" "dev" {
+  provider = doppler.dev
+}
+
+data "doppler_secrets" "prd" {
+  provider = doppler.prd
+}
+
+output "port-dev" {
+  value = nonsensitive(data.doppler_secrets.dev.map.PORT)
+}
+
+output "port-prd" {
+  value = nonsensitive(data.doppler_secrets.prd.map.PORT)
 }
 ```
 


### PR DESCRIPTION
This adds a quick example to show how you can use multiple providers to access secrets using two different Access Tokens.