### PR TITLE
Replace tabs with spaces in examples

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -14,7 +14,7 @@ Manage a Doppler project.
 ```terraform
 resource "doppler_project" "backend" {
   name = "backend"
-	description = "The main backend project"
+  description = "The main backend project"
 }
 ```
 

--- a/docs/resources/service_token.md
+++ b/docs/resources/service_token.md
@@ -13,10 +13,10 @@ Manage a Doppler service token.
 
 ```terraform
 resource "doppler_service_token" "backend_ci_token" {
-	project = "backend"
-	config = "ci"
-	name = "Builder Token"
-	access = "read"
+  project = "backend"
+  config = "ci"
+  name = "Builder Token"
+  access = "read"
 }
 
 # Service token key available as `doppler_service_token.backend_ci_token.key`

--- a/examples/resources/project.tf
+++ b/examples/resources/project.tf
@@ -1,4 +1,4 @@
 resource "doppler_project" "backend" {
   name = "backend"
-	description = "The main backend project"
+  description = "The main backend project"
 }

--- a/examples/resources/service_token.tf
+++ b/examples/resources/service_token.tf
@@ -1,8 +1,8 @@
 resource "doppler_service_token" "backend_ci_token" {
-	project = "backend"
-	config = "ci"
-	name = "Builder Token"
-	access = "read"
+  project = "backend"
+  config = "ci"
+  name = "Builder Token"
+  access = "read"
 }
 
 # Service token key available as `doppler_service_token.backend_ci_token.key`


### PR DESCRIPTION
Small fix to the example templates. They previously had a mix of tabs and spaces and now they're just spaces.
