### PR TITLE
fix: correct go module name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X terraform-provider-doppler/doppler.ProviderVersion={{.Version}}'
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X github.com/DopplerHQ/terraform-provider-doppler/doppler.ProviderVersion={{.Version}}'
   goos:
     - freebsd
     - windows

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ default: install
 
 build:
 	go build \
-		-ldflags="-X terraform-provider-doppler/doppler.ProviderVersion=dev-$(shell git rev-parse --abbrev-ref HEAD)-$(shell git rev-parse --short HEAD)" \
+		-ldflags="-X github.com/DopplerHQ/terraform-provider-doppler/doppler.ProviderVersion=dev-$(shell git rev-parse --abbrev-ref HEAD)-$(shell git rev-parse --short HEAD)" \
 		-o ${BINARY}
 
 install: build

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-provider-doppler
+module github.com/DopplerHQ/terraform-provider-doppler
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"terraform-provider-doppler/doppler"
+	"github.com/DopplerHQ/terraform-provider-doppler/doppler"
 )
 
 func main() {


### PR DESCRIPTION
I'd like to generate a Pulumi provider from your Terraform provider, but because the Go module name is incorrect - your provider can't actually be consumed as a library.