### PR TITLE
Add write contents permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       -
         name: Checkout


### PR DESCRIPTION
This permission is required to allow the runner to post the build artifacts to the release.

<img width="1225" alt="Screen Shot 2022-11-01 at 1 35 04 PM" src="https://user-images.githubusercontent.com/2954553/199300032-a2f9a6d7-1893-4e2e-b9e8-dce6919f53c8.png">
