### PR TITLE
Fix multiple token search issue

### DIFF
--- a/doppler/resource_service_token.go
+++ b/doppler/resource_service_token.go
@@ -93,7 +93,8 @@ func resourceServiceTokenRead(ctx context.Context, d *schema.ResourceData, m int
 	var token *ServiceToken
 	for _, searchToken := range tokens {
 		if searchToken.Slug == slug {
-			token = &searchToken
+			tokenRef := searchToken
+			token = &tokenRef
 		}
 	}
 


### PR DESCRIPTION
In Go, the loop iterator variable is a single variable that takes different values in each loop iteration. When we try to take a reference of the iteration var, its value changes with each iteration. This results in the loop always "finding" the final element. To fix this, we can make a copy of the `searchToken` variable and take its reference instead.

https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable

Closes ENG-5362
Closes #32 