### PR TITLE
Make external secret name changes get picked up

### DIFF
--- a/doppler/resource_secret.go
+++ b/doppler/resource_secret.go
@@ -89,7 +89,12 @@ func resourceSecretRead(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 
-	setErr := d.Set("value", secret.Value.Raw)
+	setErr := d.Set("name", secret.Name)
+	if setErr != nil {
+		return diag.FromErr(setErr)
+	}
+
+	setErr = d.Set("value", secret.Value.Raw)
 	if setErr != nil {
 		return diag.FromErr(setErr)
 	}


### PR DESCRIPTION
When you fetch a non-existent secret from the Doppler API, you get a payload that looks like this:

```json
{
  "name": "FOOBAR",
  "value": {
    "raw": null,
    "computed": null
  },
  "success": true
}
```

This means that after the initial secret creation, if someone changed the name of the secret outside of Terraform, the only way Terraform would know is due to the secret comparison (`null` vs the expected value). This usually works fine, but if you're using Terraform to seed secrets and expect the value to change, you would add a lifecyle argument like this:

```hcl
lifecycle {
  ignore_change = [ value ]
}
```

This ignores the value as expected, but has the side-effect of making it so if someone renames the secret, Terraform will never notice because it always gets an empty object with the correct name back. To fix this, we now check if the Raw and Computed values of the secret are empty. If they are, we return a truly empty secret object rather than what we got back from the API.