### PR TITLE
Recreate missing resources rather than erroring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,16 @@ NAME=doppler
 BINARY=terraform-provider-${NAME}
 # Only used for local development
 VERSION=0.0.1
-OS_ARCH=darwin_$$(uname -m)
+ARCH := $(shell uname -m)
+# required because Terraform always evaluates x86_64
+# architectures as amd64
+ifeq ($(ARCH), x86_64)
+  OS_ARCH=darwin_amd64
+else ifeq ($(ARCH), arm64)
+  OS_ARCH=darwin_arm64
+else
+  $(error $(ARCH) is currently untested. Please update the Makefile to handle your architecture properly.)
+endif
 
 default: install
 

--- a/doppler/provider_utils.go
+++ b/doppler/provider_utils.go
@@ -1,0 +1,43 @@
+package doppler
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type CustomNotFoundError struct {
+	Message string
+}
+
+func (e *CustomNotFoundError) Error() string {
+	return fmt.Sprintf("Doppler Error: %s", e.Message)
+}
+
+func handleNotFoundError(err error, d *schema.ResourceData) diag.Diagnostics {
+	isNotFoundError := false
+
+	if apiError, ok := err.(*APIError); ok && apiError.Response != nil && apiError.Response.HTTPResponse.StatusCode == 404 {
+		isNotFoundError = true
+	}
+
+	if _, ok := err.(*CustomNotFoundError); ok {
+		isNotFoundError = true
+	}
+
+	if isNotFoundError {
+		// the resource no longer exists, so reset its ID so Terraform will
+		// generate a plan that recreates it
+		d.SetId("")
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  err.Error(),
+				Detail:   "Resource was not found, so it was removed from state and is being recreated.",
+			},
+		}
+	}
+
+	return diag.FromErr(err)
+}

--- a/doppler/resource_config.go
+++ b/doppler/resource_config.go
@@ -84,7 +84,7 @@ func resourceConfigRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	config, err := client.GetConfig(ctx, project, name)
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d)
 	}
 
 	if err = d.Set("project", config.Project); err != nil {

--- a/doppler/resource_environment.go
+++ b/doppler/resource_environment.go
@@ -84,7 +84,7 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, m inte
 
 	environment, err := client.GetEnvironment(ctx, project, slug)
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d)
 	}
 
 	if err = d.Set("slug", environment.Slug); err != nil {

--- a/doppler/resource_integration.go
+++ b/doppler/resource_integration.go
@@ -101,7 +101,7 @@ func (builder ResourceIntegrationBuilder) ReadContextFunc() schema.ReadContextFu
 
 		integ, err := client.GetIntegration(ctx, slug)
 		if err != nil {
-			return diag.FromErr(err)
+			return handleNotFoundError(err, d)
 		}
 
 		if err = d.Set("name", integ.Name); err != nil {

--- a/doppler/resource_project.go
+++ b/doppler/resource_project.go
@@ -70,7 +70,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	project, err := client.GetProject(ctx, name)
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d)
 	}
 
 	if err = d.Set("name", project.Name); err != nil {

--- a/doppler/resource_secret.go
+++ b/doppler/resource_secret.go
@@ -85,7 +85,7 @@ func resourceSecretRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	secret, err := client.GetSecret(ctx, project, config, name)
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d)
 	}
 
 	if err = d.Set("value", secret.Value.Raw); err != nil {

--- a/doppler/resource_service_token.go
+++ b/doppler/resource_service_token.go
@@ -86,7 +86,7 @@ func resourceServiceTokenRead(ctx context.Context, d *schema.ResourceData, m int
 
 	tokens, err := client.GetServiceTokens(ctx, project, config)
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d)
 	}
 
 	var token *ServiceToken
@@ -98,7 +98,8 @@ func resourceServiceTokenRead(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	if token == nil {
-		return diag.Errorf("Could not find service token")
+		err := &CustomNotFoundError{Message: "Could not find requested service token"}
+		return handleNotFoundError(err, d)
 	}
 
 	if err = d.Set("project", token.Project); err != nil {

--- a/doppler/resource_sync.go
+++ b/doppler/resource_sync.go
@@ -83,7 +83,7 @@ func (builder ResourceSyncBuilder) ReadContextFunc() schema.ReadContextFunc {
 
 		sync, err := client.GetSync(ctx, config, project, name)
 		if err != nil {
-			return diag.FromErr(err)
+			return handleNotFoundError(err, d)
 		}
 
 		if err = d.Set("integration", sync.Integration); err != nil {


### PR DESCRIPTION
This updates our handling for missing resources. Previously, if any resource was missing, the whole run would fail with an error like this:

```
│ Error: Could not find service token
│
│   with doppler_service_token.rocket_ci_token,
│   on main.tf line 79, in resource "doppler_service_token" "rocket_ci_token":
│   79: resource "doppler_service_token" "rocket_ci_token" {
```

Instead, the behavior we want is for a warning to get produced, but Terraform should generate a plan that re-creates the resource:

```
Terraform will perform the following actions:

  # doppler_service_token.rocket_ci_token will be created
  + resource "doppler_service_token" "rocket_ci_token" {
      + access  = "read"
      + config  = "ci"
      + id      = (known after apply)
      + key     = (sensitive value)
      + name    = "Rocket CI Token"
      + project = "rocket"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Warning: Doppler Error: Could not find requested service token
│
│   with doppler_service_token.rocket_ci_token,
│   on main.tf line 79, in resource "doppler_service_token" "rocket_ci_token":
│   79: resource "doppler_service_token" "rocket_ci_token" {
│
│ Resource was not found, so it was removed from state and is being recreated.
```

This behavior now applies to all resource types.