### PR TITLE
Add import support for project, environment, config, and secret resources

### DIFF
--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -31,3 +31,7 @@ resource "doppler_config" "backend_ci_github" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Resource ID Format
+
+Resource IDs are in the format `<project-name>.<environment-slug>.<config-name>`.

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -31,3 +31,7 @@ resource "doppler_environment" "backend_ci" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Resource ID Format
+
+Resource IDs are in the format `<project-name>.<environment-slug>`.

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -41,7 +41,15 @@ output "resource_value" {
 - `project` (String) The name of the Doppler project
 - `value` (String, Sensitive) The raw secret value
 
+### Optional
+
+- `visibility` (String) The visibility of the secret
+
 ### Read-Only
 
 - `computed` (String, Sensitive) The computed secret value, after resolving secret references
 - `id` (String) The ID of this resource.
+
+## Resource ID Format
+
+Resource IDs are in the format `<project-name>.<config-name>.<secret-name>`.

--- a/doppler/resource_config.go
+++ b/doppler/resource_config.go
@@ -11,6 +11,9 @@ func resourceConfig() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceConfigCreate,
 		ReadContext:   resourceConfigRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		UpdateContext: resourceConfigUpdate,
 		DeleteContext: resourceConfigDelete,
 		Schema: map[string]*schema.Schema{

--- a/doppler/resource_environment.go
+++ b/doppler/resource_environment.go
@@ -11,6 +11,9 @@ func resourceEnvironment() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceEnvironmentCreate,
 		ReadContext:   resourceEnvironmentRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		UpdateContext: resourceEnvironmentUpdate,
 		DeleteContext: resourceEnvironmentDelete,
 		Schema: map[string]*schema.Schema{
@@ -92,6 +95,10 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, m inte
 	}
 
 	if err = d.Set("name", environment.Name); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err = d.Set("project", environment.Project); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/doppler/resource_project.go
+++ b/doppler/resource_project.go
@@ -11,6 +11,9 @@ func resourceProject() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceProjectCreate,
 		ReadContext:   resourceProjectRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		UpdateContext: resourceProjectUpdate,
 		DeleteContext: resourceProjectDelete,
 		Schema: map[string]*schema.Schema{

--- a/doppler/resource_secret.go
+++ b/doppler/resource_secret.go
@@ -15,6 +15,9 @@ func resourceSecret() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceSecretUpdate,
 		ReadContext:   resourceSecretRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		UpdateContext: resourceSecretUpdate,
 		DeleteContext: resourceSecretDelete,
 		Schema: map[string]*schema.Schema{
@@ -126,6 +129,18 @@ func resourceSecretRead(ctx context.Context, d *schema.ResourceData, m interface
 			"One or more secret fields are restricted: %v. "+
 				"You must use a service account or service token to manage these resources. "+
 				"Otherwise, Terraform cannot fetch these restricted secrets to check the validity of their state.", nilFields))
+	}
+
+	if err = d.Set("project", project); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err = d.Set("config", config); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err = d.Set("name", name); err != nil {
+		return diag.FromErr(err)
 	}
 
 	if err = d.Set("value", secret.Value.Raw); err != nil {

--- a/templates/resources/config.md.tmpl
+++ b/templates/resources/config.md.tmpl
@@ -14,3 +14,7 @@ Manage a Doppler config.
 {{tffile "examples/resources/config.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
+
+## Resource ID Format
+
+Resource IDs are in the format `<project-name>.<environment-slug>.<config-name>`.

--- a/templates/resources/environment.md.tmpl
+++ b/templates/resources/environment.md.tmpl
@@ -14,3 +14,7 @@ Manage a Doppler environment.
 {{tffile "examples/resources/environment.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
+
+## Resource ID Format
+
+Resource IDs are in the format `<project-name>.<environment-slug>`.

--- a/templates/resources/secret.md.tmpl
+++ b/templates/resources/secret.md.tmpl
@@ -14,3 +14,7 @@ Manage a single Doppler secret in a config.
 {{tffile "examples/resources/secret.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
+
+## Resource ID Format
+
+Resource IDs are in the format `<project-name>.<config-name>.<secret-name>`.


### PR DESCRIPTION
This PR adds `terraform import` support for projects, environments, configs, and secrets.

Closes ENG-5449

Closes #37 