### PR TITLE
Add tag support to doppler_secrets_sync_aws_secrets_manager

### DIFF
--- a/docs/resources/integration_aws_secrets_manager.md
+++ b/docs/resources/integration_aws_secrets_manager.md
@@ -71,6 +71,7 @@ resource "doppler_secrets_sync_aws_secrets_manager" "backend_prod" {
 
   region = "us-east-1"
   path   = "/backend/"
+  tags   = { myTag = "enabled" }
 }
 ```
 

--- a/docs/resources/secrets_sync_aws_secrets_manager.md
+++ b/docs/resources/secrets_sync_aws_secrets_manager.md
@@ -71,6 +71,7 @@ resource "doppler_secrets_sync_aws_secrets_manager" "backend_prod" {
 
   region = "us-east-1"
   path   = "/backend/"
+  tags   = { myTag = "enabled" }
 }
 ```
 
@@ -84,6 +85,10 @@ resource "doppler_secrets_sync_aws_secrets_manager" "backend_prod" {
 - `path` (String) The path to the secret in AWS
 - `project` (String) The name of the Doppler project
 - `region` (String) The AWS region
+
+### Optional
+
+- `tags` (Map of String) AWS tags to attach to the secrets
 
 ### Read-Only
 

--- a/doppler/resource_sync_types.go
+++ b/doppler/resource_sync_types.go
@@ -19,11 +19,21 @@ func resourceSyncAWSSecretsManager() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
+			"tags": {
+				Description: "AWS tags to attach to the secrets",
+				Type:        schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 		DataBuilder: func(d *schema.ResourceData) IntegrationData {
 			return map[string]interface{}{
 				"region": d.Get("region"),
 				"path":   d.Get("path"),
+				"tags":   d.Get("tags"),
 			}
 		},
 	}

--- a/examples/resources/integration_aws_secrets_manager.tf
+++ b/examples/resources/integration_aws_secrets_manager.tf
@@ -57,5 +57,6 @@ resource "doppler_secrets_sync_aws_secrets_manager" "backend_prod" {
 
   region = "us-east-1"
   path   = "/backend/"
+  tags   = { myTag = "enabled" }
 }
 


### PR DESCRIPTION
This plumbs through tag support to `doppler_secrets_sync_aws_secrets_manager`.

Closes ENG-7065.