### PR TITLE
Set ForceNew for doppler_secret project and config

### DIFF
--- a/doppler/resource_secret.go
+++ b/doppler/resource_secret.go
@@ -25,11 +25,15 @@ func resourceSecret() *schema.Resource {
 				Description: "The name of the Doppler project",
 				Type:        schema.TypeString,
 				Required:    true,
+				// Secrets cannot be moved directly from one project to another, they must be re-created
+				ForceNew: true,
 			},
 			"config": {
 				Description: "The name of the Doppler config",
 				Type:        schema.TypeString,
 				Required:    true,
+				// Secrets cannot be moved directly from one config to another, they must be re-created
+				ForceNew: true,
 			},
 			"name": {
 				Description: "The name of the Doppler secret",


### PR DESCRIPTION
A `doppler_secret` resource cannot be moved from one project or config to another. This adds `ForceNew` to ensure that secrets are properly deleted and recreated if these fields change.

Closes ENG-7638
Closes #77