### PR TITLE
Ignore order of project_member environments

### DIFF
--- a/docs/resources/project_member_group.md
+++ b/docs/resources/project_member_group.md
@@ -32,7 +32,7 @@ resource "doppler_project_member_group" "backend_engineering" {
 
 ### Optional
 
-- `environments` (List of String) The environments in the project where this access will apply (null or omitted for roles with access to all environments)
+- `environments` (Set of String) The environments in the project where this access will apply (null or omitted for roles with access to all environments)
 
 ### Read-Only
 

--- a/docs/resources/project_member_service_account.md
+++ b/docs/resources/project_member_service_account.md
@@ -32,7 +32,7 @@ resource "doppler_project_member_service_account" "backend_ci" {
 
 ### Optional
 
-- `environments` (List of String) The environments in the project where this access will apply (null or omitted for roles with access to all environments)
+- `environments` (Set of String) The environments in the project where this access will apply (null or omitted for roles with access to all environments)
 
 ### Read-Only
 

--- a/doppler/resource_project_member.go
+++ b/doppler/resource_project_member.go
@@ -37,7 +37,7 @@ func (builder ResourceProjectMemberBuilder) Build() *schema.Resource {
 		},
 		"environments": {
 			Description: "The environments in the project where this access will apply (null or omitted for roles with access to all environments)",
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet,
 			Optional:    true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
@@ -67,7 +67,7 @@ func (builder ResourceProjectMemberBuilder) CreateContextFunc() schema.CreateCon
 		project := d.Get("project").(string)
 		role := d.Get("role").(string)
 
-		rawEnvironments := d.Get("environments").([]interface{})
+		rawEnvironments := d.Get("environments").(*schema.Set).List()
 		environments := make([]string, len(rawEnvironments))
 		for i, v := range rawEnvironments {
 			environments[i] = v.(string)
@@ -113,7 +113,7 @@ func (builder ResourceProjectMemberBuilder) UpdateContextFunc() schema.UpdateCon
 
 		var environments []string
 		if d.HasChange("environments") {
-			rawEnvironments := d.Get("environments").([]interface{})
+			rawEnvironments := d.Get("environments").(*schema.Set).List()
 			environments = make([]string, len(rawEnvironments))
 			for i, v := range rawEnvironments {
 				environments[i] = v.(string)


### PR DESCRIPTION
Release note: Utilize a TypeSet. No change in usage.

[Force push](https://github.com/DopplerHQ/terraform-provider-doppler/compare/7c377efc93fad5a0b3c0622a5adca04ddd9d03bc..83a3fa243e17992d79c99c9a217ac5a0c58d93ff) squashes the extra ["remove" commit](https://github.com/DopplerHQ/terraform-provider-doppler/pull/79/commits/7c377efc93fad5a0b3c0622a5adca04ddd9d03bc) which was left initially for review purposes only.



Closes ENG-7578
Closes #73 