### PR TITLE
Add support for config inheritance

### DIFF
--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -28,8 +28,14 @@ resource "doppler_config" "backend_ci_github" {
 - `name` (String) The name of the Doppler config
 - `project` (String) The name of the Doppler project where the config is located
 
+### Optional
+
+- `inheritable` (Boolean) Whether or not the Doppler config can be inherited by other configs
+- `inherits` (List of String) A list of other Doppler config descriptors that this config inherits from. Descriptors match the format "project.config" (e.g. backend.stg), which is most easily retrieved as the computed descriptor of a doppler_config resource (e.g. doppler_config.backend_stg.descriptor)
+
 ### Read-Only
 
+- `descriptor` (String) The descriptor (project.config) of the Doppler config
 - `id` (String) The ID of this resource.
 
 ## Import

--- a/doppler/api.go
+++ b/doppler/api.go
@@ -894,6 +894,27 @@ func (client APIClient) RenameConfig(ctx context.Context, project string, curren
 	return &result.Config, nil
 }
 
+func (client APIClient) UpdateConfigInheritable(ctx context.Context, project string, config string, inheritable bool) (*Config, error) {
+	payload := map[string]interface{}{
+		"project":     project,
+		"config":      config,
+		"inheritable": inheritable,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &APIError{Err: err, Message: "Unable to serialize config"}
+	}
+	response, err := client.PerformRequestWithRetry(ctx, "POST", "/v3/configs/config/inheritable", []QueryParam{}, body)
+	if err != nil {
+		return nil, err
+	}
+	var result ConfigResponse
+	if err = json.Unmarshal(response.Body, &result); err != nil {
+		return nil, &APIError{Err: err, Message: "Unable to parse config"}
+	}
+	return &result.Config, nil
+}
+
 func (client APIClient) DeleteConfig(ctx context.Context, project string, name string) error {
 	payload := map[string]interface{}{
 		"project": project,

--- a/doppler/api.go
+++ b/doppler/api.go
@@ -915,6 +915,34 @@ func (client APIClient) UpdateConfigInheritable(ctx context.Context, project str
 	return &result.Config, nil
 }
 
+func (client APIClient) UpdateConfigInherits(ctx context.Context, project string, config string, inherits []ConfigDescriptor) (*Config, error) {
+	payload := map[string]interface{}{
+		"project":  project,
+		"config":   config,
+		"inherits": inherits,
+	}
+
+	if len(inherits) == 0 {
+		// If we don't manually instantiate an empty array here, go will marshal the inherits property as nil instead of []
+		payload["inherits"] = []ConfigDescriptor{}
+	}
+
+	body, err := json.Marshal(payload)
+
+	if err != nil {
+		return nil, &APIError{Err: err, Message: "Unable to serialize config"}
+	}
+	response, err := client.PerformRequestWithRetry(ctx, "POST", "/v3/configs/config/inherits", []QueryParam{}, body)
+	if err != nil {
+		return nil, err
+	}
+	var result ConfigResponse
+	if err = json.Unmarshal(response.Body, &result); err != nil {
+		return nil, &APIError{Err: err, Message: "Unable to parse config"}
+	}
+	return &result.Config, nil
+}
+
 func (client APIClient) DeleteConfig(ctx context.Context, project string, name string) error {
 	payload := map[string]interface{}{
 		"project": project,

--- a/doppler/models.go
+++ b/doppler/models.go
@@ -177,6 +177,12 @@ type Config struct {
 	Locked      bool   `json:"locked"`
 	Root        bool   `json:"root"`
 	CreatedAt   string `json:"created_at"`
+	Inheritable bool               `json:"inheritable"`
+}
+
+type ConfigDescriptor struct {
+	Project string `json:"project"`
+	Config  string `json:"config"`
 }
 
 type ConfigResponse struct {

--- a/doppler/models.go
+++ b/doppler/models.go
@@ -170,14 +170,15 @@ type WebhookResponse struct {
 }
 
 type Config struct {
-	Slug        string `json:"slug"`
-	Name        string `json:"name"`
-	Project     string `json:"project"`
-	Environment string `json:"environment"`
-	Locked      bool   `json:"locked"`
-	Root        bool   `json:"root"`
-	CreatedAt   string `json:"created_at"`
+	Slug        string             `json:"slug"`
+	Name        string             `json:"name"`
+	Project     string             `json:"project"`
+	Environment string             `json:"environment"`
+	Locked      bool               `json:"locked"`
+	Root        bool               `json:"root"`
+	CreatedAt   string             `json:"created_at"`
 	Inheritable bool               `json:"inheritable"`
+	Inherits    []ConfigDescriptor `json:"inherits"`
 }
 
 type ConfigDescriptor struct {


### PR DESCRIPTION
This adds `inheritable` and `inherits` as properties of the `doppler_config` resource. It also adds support for defining the root config of an environment as a resource (which cannot be manually created or deleted - it's tied to the environment) so that the inheritance properties can be specified.

An example configuration might look like this:


```terraform
terraform {
  required_providers {
    doppler = {
      source = "doppler.com/core/doppler"
    }
  }
}

resource "doppler_project" "backend" {
  name = "backend"
}

resource "doppler_environment" "backend_dev" {
  project = doppler_project.backend.name
  slug    = "dev"
  name    = "Development"
}

resource "doppler_environment" "backend_stg" {
  project = doppler_project.backend.name
  slug    = "stg"
  name    = "Staging"
}

# Terraform sees that the config name matches the environment and "imports" it rather than creating it
resource "doppler_config" "backend_stg" {
  project     = doppler_project.backend.name
  environment = doppler_environment.backend_stg.slug
  name        = "stg"
  inheritable = true
}

resource "doppler_config" "backend_dev" {
  project     = doppler_project.backend.name
  environment = doppler_environment.backend_dev.slug
  name        = "dev"
  inherits = [doppler_config.backend_stg.id]
}

resource "doppler_config" "backend_dev_branch" {
  project     = doppler_project.backend.name
  environment = doppler_environment.backend_dev.slug
  name        = "dev_branch"
}

```

Depends on https://github.com/DopplerHQ/server/pull/7068

Closes ENG-8535
