### PR TITLE
docs: Improve doc for AWS Sync resources

### DIFF
--- a/docs/resources/secrets_sync_aws_parameter_store.md
+++ b/docs/resources/secrets_sync_aws_parameter_store.md
@@ -99,7 +99,7 @@ resource "doppler_secrets_sync_aws_parameter_store" "backend_prod" {
 - `kms_key_id` (String) The AWS KMS key used to encrypt the parameter (ID, Alias, or ARN)
 - `secure_string` (Boolean) Whether or not the parameters are stored as a secure string
 - `tags` (Map of String) AWS tags to attach to the parameters
-- `update_resource_tags` (String) Behavior for AWS resource tags on updates (never update, upsert tags (leaving non-Doppler tags alone), replace tags (remove non-Doppler tags))
+- `update_resource_tags` (String) Behavior for AWS resource tags on updates (`never` update, `upsert` tags (leaving non-Doppler tags alone), `replace` tags (remove non-Doppler tags))
 
 ### Read-Only
 

--- a/docs/resources/secrets_sync_aws_secrets_manager.md
+++ b/docs/resources/secrets_sync_aws_secrets_manager.md
@@ -94,8 +94,8 @@ resource "doppler_secrets_sync_aws_secrets_manager" "backend_prod" {
 - `kms_key_id` (String) The AWS KMS key used to encrypt the secret (ID, Alias, or ARN)
 - `path_behavior` (String) The behavior to modify the provided path. Either `add_doppler_suffix` (default) which appends `doppler` to the provided path or `none` which leaves the path unchanged.
 - `tags` (Map of String) AWS tags to attach to the secrets
-- `update_metadata` (Boolean) If enabled, Doppler will update the AWS secret metadata (e.g. KMS key) during every sync. If disabled, Doppler will only set secret metadata for new AWS secrets. Note that Doppler never updates tags for existing AWS secrets.
-- `update_resource_tags` (String) Behavior for AWS resource tags on updates (never update, upsert tags (leaving non-Doppler tags alone), replace tags (remove non-Doppler tags))
+- `update_metadata` (Boolean) If enabled, Doppler will update the AWS secret metadata (e.g. KMS key) during every sync. If disabled, Doppler will only set secret metadata for new AWS secrets.
+- `update_resource_tags` (String) Behavior for AWS resource tags on updates (`never` update, `upsert` tags (leaving non-Doppler tags alone), `replace` tags (remove non-Doppler tags))
 
 ### Read-Only
 

--- a/doppler/resource_sync_types.go
+++ b/doppler/resource_sync_types.go
@@ -36,14 +36,14 @@ func resourceSyncAWSSecretsManager() *schema.Resource {
 				ForceNew: true,
 			},
 			"update_metadata": {
-				Description: "If enabled, Doppler will update the AWS secret metadata (e.g. KMS key) during every sync. If disabled, Doppler will only set secret metadata for new AWS secrets. Note that Doppler never updates tags for existing AWS secrets.",
+				Description: "If enabled, Doppler will update the AWS secret metadata (e.g. KMS key) during every sync. If disabled, Doppler will only set secret metadata for new AWS secrets.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
 			},
 
 			"update_resource_tags": {
-				Description:  "Behavior for AWS resource tags on updates (never update, upsert tags (leaving non-Doppler tags alone), replace tags (remove non-Doppler tags))",
+				Description:  "Behavior for AWS resource tags on updates (`never` update, `upsert` tags (leaving non-Doppler tags alone), `replace` tags (remove non-Doppler tags))",
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
@@ -143,7 +143,7 @@ func resourceSyncAWSParameterStore() *schema.Resource {
 				ForceNew: true,
 			},
 			"update_resource_tags": {
-				Description:  "Behavior for AWS resource tags on updates (never update, upsert tags (leaving non-Doppler tags alone), replace tags (remove non-Doppler tags))",
+				Description:  "Behavior for AWS resource tags on updates (`never` update, `upsert` tags (leaving non-Doppler tags alone), `replace` tags (remove non-Doppler tags))",
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,


### PR DESCRIPTION
This pull request includes updates to the documentation and codebase to improve the descriptions of certain parameters related to AWS resource tags and metadata updates. The most important changes include clarifying the descriptions of `update_resource_tags` and `update_metadata` parameters.

Documentation updates:

* [`docs/resources/secrets_sync_aws_parameter_store.md`](diffhunk://#diff-319a462840aa77cf7fe2bdf95f52721132221b1a10488a8b2ed11ee0062840caL102-R102): Updated the description of the `update_resource_tags` parameter to use backticks for the possible values (`never`, `upsert`, `replace`).
* [`docs/resources/secrets_sync_aws_secrets_manager.md`](diffhunk://#diff-b7da6ce89238d4aa3ab9578aa77c14f49a8840215bb5a8efe3d816581b8784f3L97-R98): Updated the descriptions of the `update_metadata` and `update_resource_tags` parameters to use backticks for the possible values and removed redundant information.

Codebase updates:

* [`doppler/resource_sync_types.go`](diffhunk://#diff-2a7dfff52f392b77867e9fffe5f420fa34513fc0b9c6550871745c551950027cL39-R46): Updated the description of the `update_metadata` parameter in the `resourceSyncAWSSecretsManager` function to remove redundant information.
* [`doppler/resource_sync_types.go`](diffhunk://#diff-2a7dfff52f392b77867e9fffe5f420fa34513fc0b9c6550871745c551950027cL39-R46): Updated the description of the `update_resource_tags` parameter in both the `resourceSyncAWSSecretsManager` and `resourceSyncAWSParameterStore` functions to use backticks for the possible values (`never`, `upsert`, `replace`). [[1]](diffhunk://#diff-2a7dfff52f392b77867e9fffe5f420fa34513fc0b9c6550871745c551950027cL39-R46) [[2]](diffhunk://#diff-2a7dfff52f392b77867e9fffe5f420fa34513fc0b9c6550871745c551950027cL146-R146)