### PR TITLE
Add 'name' to webhook resource, support for setting name in create/update operations

### DIFF
--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -15,6 +15,7 @@ Manage a Doppler Webhook.
 resource "doppler_webhook" "ci" {
   project = doppler_project.test_proj.name
   url = "https://localhost/webhook"
+  name = "My Webhook"
   secret = "my signing secret-2"
   enabled = true
   enabled_configs = [doppler_config.ci_github.name]
@@ -41,6 +42,7 @@ resource "doppler_webhook" "ci" {
 - `authentication` (Block List, Max: 1) Authentication method used by the webhook (see [below for nested schema](#nestedblock--authentication))
 - `enabled` (Boolean) Whether the webhook is enabled or disabled.  Default to true.
 - `enabled_configs` (Set of String) Configs this webhook will trigger for
+- `name` (String) Name of the webhook
 - `payload` (String, Sensitive) The webhook's payload as a JSON string.  Leave empty to use the default webhook payload
 - `secret` (String, Sensitive) Secret used for request signing
 

--- a/doppler/api.go
+++ b/doppler/api.go
@@ -716,6 +716,7 @@ type CreateWebhookOptionalParameters struct {
 	Auth           *WebhookAuth
 	WebhookPayload string
 	EnabledConfigs []string
+	Name           string
 }
 
 func (client APIClient) CreateWebhook(ctx context.Context, project string, url string, enabled bool, options *CreateWebhookOptionalParameters) (*Webhook, error) {
@@ -740,6 +741,9 @@ func (client APIClient) CreateWebhook(ctx context.Context, project string, url s
 		}
 		if options.EnabledConfigs != nil {
 			payload["enableConfigs"] = options.EnabledConfigs
+		}
+		if options.Name != "" {
+			payload["name"] = options.Name
 		}
 	}
 
@@ -792,7 +796,7 @@ func (client APIClient) DisableWebhook(ctx context.Context, project string, slug
 	return &result.Webhook, nil
 }
 
-func (client APIClient) UpdateWebhook(ctx context.Context, project string, slug string, webhookUrl string, secret string, webhookPayload string, enabledConfigs []string, disabledConfigs []string, auth WebhookAuth) (*Webhook, error) {
+func (client APIClient) UpdateWebhook(ctx context.Context, project string, slug string, webhookUrl string, secret string, webhookPayload string, webhookName string, enabledConfigs []string, disabledConfigs []string, auth WebhookAuth) (*Webhook, error) {
 	params := []QueryParam{
 		{Key: "project", Value: project},
 	}
@@ -801,6 +805,7 @@ func (client APIClient) UpdateWebhook(ctx context.Context, project string, slug 
 	payload["url"] = webhookUrl
 	payload["secret"] = secret
 	payload["payload"] = webhookPayload
+	payload["name"] = webhookName
 	payload["enableConfigs"] = enabledConfigs
 	payload["disableConfigs"] = disabledConfigs
 	payload["authentication"] = auth

--- a/doppler/api.go
+++ b/doppler/api.go
@@ -805,7 +805,11 @@ func (client APIClient) UpdateWebhook(ctx context.Context, project string, slug 
 	payload["url"] = webhookUrl
 	payload["secret"] = secret
 	payload["payload"] = webhookPayload
-	payload["name"] = webhookName
+	if webhookName != "" {
+		payload["name"] = webhookName
+	} else {
+		payload["name"] = nil
+	}
 	payload["enableConfigs"] = enabledConfigs
 	payload["disableConfigs"] = disabledConfigs
 	payload["authentication"] = auth

--- a/doppler/models.go
+++ b/doppler/models.go
@@ -160,6 +160,7 @@ type WebhookAuth struct {
 
 type Webhook struct {
 	Slug           string   `json:"id"`
+	Name           string   `json:"name"`
 	Url            string   `json:"url"`
 	Enabled        bool     `json:"enabled"`
 	EnabledConfigs []string `json:"enabledConfigs"`

--- a/doppler/resource_webhook.go
+++ b/doppler/resource_webhook.go
@@ -43,6 +43,11 @@ func resourceWebhook() *schema.Resource {
 				Optional:    true,
 				Sensitive:   true,
 			},
+			"name": {
+				Description: "Name of the webhook",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			"authentication": {
 				Description: "Authentication method used by the webhook",
 				Type:        schema.TypeList,
@@ -98,6 +103,7 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, m interf
 	enabled := d.Get("enabled").(bool)
 	secret := d.Get("secret").(string)
 	payload := d.Get("payload").(string)
+	name := d.Get("name").(string)
 
 	rawEnabledConfigs := d.Get("enabled_configs").(*schema.Set).List()
 	enabledConfigs := make([]string, len(rawEnabledConfigs))
@@ -105,7 +111,7 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, m interf
 		enabledConfigs[i] = v.(string)
 	}
 
-	options := CreateWebhookOptionalParameters{Secret: secret, WebhookPayload: payload, EnabledConfigs: enabledConfigs}
+	options := CreateWebhookOptionalParameters{Secret: secret, WebhookPayload: payload, EnabledConfigs: enabledConfigs, Name: name}
 
 	authConfigList := d.Get("authentication").([]interface{})
 
@@ -141,6 +147,7 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	project := d.Get("project").(string)
 	secret := d.Get("secret").(string)
 	payload := d.Get("payload").(string)
+	name := d.Get("name").(string)
 
 	if d.HasChange("enabled") {
 		if d.Get("enabled").(bool) {
@@ -204,7 +211,7 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		auth = WebhookAuth{Type: "None"}
 	}
 
-	webhook, err := client.UpdateWebhook(ctx, project, slug, url, secret, payload, enabledConfigs, disabledConfigs, auth)
+	webhook, err := client.UpdateWebhook(ctx, project, slug, url, secret, payload, name, enabledConfigs, disabledConfigs, auth)
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/doppler/resource_webhook.go
+++ b/doppler/resource_webhook.go
@@ -248,6 +248,10 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return diag.FromErr(err)
 	}
 
+	if err = d.Set("name", webhook.Name); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return diags
 }
 

--- a/examples/resources/webhook.tf
+++ b/examples/resources/webhook.tf
@@ -1,6 +1,7 @@
 resource "doppler_webhook" "ci" {
   project = doppler_project.test_proj.name
   url = "https://localhost/webhook"
+  name = "My Webhook"
   secret = "my signing secret-2"
   enabled = true
   enabled_configs = [doppler_config.ci_github.name]


### PR DESCRIPTION
This adds support to the terraform provider for the 'name' field on webhook creation and update.

I've tested locally with creation and update of webhooks via Terraform.

Closes ENG-8677.