### PR TITLE
Fix issue preventing secrets from being deleted

### DIFF
--- a/doppler/models.go
+++ b/doppler/models.go
@@ -57,14 +57,14 @@ func parseSecretId(id string) (project string, config string, name string, err e
 }
 
 type ChangeRequest struct {
-	OriginalName       *string   `json:"originalName,omitempty"`
-	OriginalValue      *string   `json:"originalValue,omitempty"`
-	OriginalVisibility *string   `json:"originalVisibility,omitempty"`
-	Name               string    `json:"name"`
-	Value              *string   `json:"value"`
-	ShouldDelete       bool      `json:"shouldDelete"`
-	Visibility         string    `json:"visibility,omitempty"`
-	ValueType          ValueType `json:"valueType,omitempty"`
+	OriginalName       *string    `json:"originalName,omitempty"`
+	OriginalValue      *string    `json:"originalValue,omitempty"`
+	OriginalVisibility *string    `json:"originalVisibility,omitempty"`
+	Name               string     `json:"name"`
+	Value              *string    `json:"value"`
+	ShouldDelete       bool       `json:"shouldDelete"`
+	Visibility         string     `json:"visibility,omitempty"`
+	ValueType          *ValueType `json:"valueType,omitempty"`
 }
 
 type ValueType struct {

--- a/doppler/resource_secret.go
+++ b/doppler/resource_secret.go
@@ -91,7 +91,7 @@ func resourceSecretUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 		Name:       name,
 		Value:      &value,
 		Visibility: visibility,
-		ValueType:  ValueType{Type: valueType},
+		ValueType:  &ValueType{Type: valueType},
 	}
 	if !d.IsNewResource() {
 		previousNameValue, _ := d.GetChange("name")


### PR DESCRIPTION
`valueType` was being passed as `{"type": ""}` which is invalid.