### PR TITLE
Add auto PR comment for manually updated docs

### DIFF
--- a/.github/workflows/tfdocs.yaml
+++ b/.github/workflows/tfdocs.yaml
@@ -33,6 +33,7 @@ jobs:
           cat final_hash.txt
 
       - name: Compare hashes and fail if different
+        id: compare_hashes
         run: |
           if ! diff initial_hash.txt final_hash.txt; then
             echo "Docs are not up to date! Run 'make tfplugindocs' and commit the changes."
@@ -40,3 +41,13 @@ jobs:
           else
             echo "Docs are up to date."
           fi
+
+      - name: Comment PR
+        if: always()
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            ## :warning: Docs are not up to date!
+            These docs aren't rendered into markdown automatically and you need to generate them manually with `make tfdocs` command.
+          mode: ${{ steps.compare_hashes.outcome == 'failure' && 'recreate' || 'delete' }}
+          comment-tag: compare-hashes


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/tfdocs.yaml` file to enhance the workflow for checking and commenting on documentation updates. The most important changes include adding an ID to the hash comparison step and introducing a new step to comment on the pull request if the documentation is not up to date.

Enhancements to documentation workflow:

* [`.github/workflows/tfdocs.yaml`](diffhunk://#diff-e27a145338ca3832b42b6f79ce3508b63b618379278b828d46d3cb2c82205b7dR36-R53): Added an `id` to the hash comparison step to enable referencing its outcome in subsequent steps.
* [`.github/workflows/tfdocs.yaml`](diffhunk://#diff-e27a145338ca3832b42b6f79ce3508b63b618379278b828d46d3cb2c82205b7dR36-R53): Introduced a new step to comment on the pull request if the documentation is not up to date, using the `thollander/actions-comment-pull-request` action.

Current logic is to re-create comment (mode: recreate), but it can be changed to update existing comment (mode: upsert) 

Comment will be looking like this one on the screenshot, when there is no "diff"  is detected comment will be deleted.

<img width="948" alt="image" src="https://github.com/user-attachments/assets/5c69d119-ab30-49c0-8f0b-3ae014855541" />