### PR TITLE
Fix tfdocs workflow to create comment only on PR event

### DIFF
--- a/.github/workflows/tfdocs.yaml
+++ b/.github/workflows/tfdocs.yaml
@@ -43,7 +43,7 @@ jobs:
           fi
 
       - name: Comment PR
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/tfdocs.yaml` file. The change updates the condition for the "Comment PR" step to only run if the GitHub event is a pull request.

* [`.github/workflows/tfdocs.yaml`](diffhunk://#diff-e27a145338ca3832b42b6f79ce3508b63b618379278b828d46d3cb2c82205b7dL46-R46): Modified the `if` condition for the "Comment PR" step to include `github.event_name == 'pull_request'`.