### PR TITLE
Update docs subcategories

### DIFF
--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_group Data Source - terraform-provider-doppler"
-subcategory: "Group"
+subcategory: "Groups"
 description: |-
   Retrieve an existing Doppler group.
 ---

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_user Data Source - terraform-provider-doppler"
-subcategory: "User"
+subcategory: "Users"
 description: |-
   Retrieve an existing Doppler user.
 ---

--- a/docs/resources/change_request_policy.md
+++ b/docs/resources/change_request_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_change_request_policy Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Change Requests"
 description: |-
 	Manage a Doppler change request policy.
 ---

--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_config Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Project Structure"
 description: |-
 	Manage a Doppler config.
 ---

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_environment Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Project Structure"
 description: |-
 	Manage a Doppler environment.
 ---

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_group Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Groups"
 description: |-
 	Manage a Doppler group.
 ---

--- a/docs/resources/group_member.md
+++ b/docs/resources/group_member.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_group_member Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Groups"
 description: |-
 	Manage a Doppler user/group membership.
 ---

--- a/docs/resources/group_members.md
+++ b/docs/resources/group_members.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_group_members Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Groups"
 description: |-
 	Manage a Doppler group's memberships.
 ---

--- a/docs/resources/integration_aws_parameter_store.md
+++ b/docs/resources/integration_aws_parameter_store.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_aws_parameter_store Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an AWS Parameter Store Doppler integration.
 ---

--- a/docs/resources/integration_aws_secrets_manager.md
+++ b/docs/resources/integration_aws_secrets_manager.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_aws_secrets_manager Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an AWS Secrets Manager Doppler integration.
 ---

--- a/docs/resources/integration_azure_vault_service_principal.md
+++ b/docs/resources/integration_azure_vault_service_principal.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_azure_vault_service_principal Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an Azure Vault (Service Principal) Doppler integration.
 ---

--- a/docs/resources/integration_circleci.md
+++ b/docs/resources/integration_circleci.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_circleci Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a CircleCI Doppler integration.
 ---

--- a/docs/resources/integration_flyio.md
+++ b/docs/resources/integration_flyio.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_flyio Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a Fly.io Doppler integration.
 ---

--- a/docs/resources/integration_gcp_secret_manager.md
+++ b/docs/resources/integration_gcp_secret_manager.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_gcp_secret_manager Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a GCP Secret Manager Doppler integration.
 ---

--- a/docs/resources/integration_terraform_cloud.md
+++ b/docs/resources/integration_terraform_cloud.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_terraform_cloud Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a Terraform Cloud Doppler integration.
 ---

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_project Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Project Structure"
 description: |-
 	Manage a Doppler project.
 ---

--- a/docs/resources/project_member_group.md
+++ b/docs/resources/project_member_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_project_member_group Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Project Structure"
 description: |-
 	Manage a Doppler project group member.
 ---

--- a/docs/resources/project_member_service_account.md
+++ b/docs/resources/project_member_service_account.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_project_member_service_account Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Project Structure"
 description: |-
 	Manage a Doppler project service account member.
 ---

--- a/docs/resources/project_role.md
+++ b/docs/resources/project_role.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_project_role Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Roles"
 description: |-
 	Manage a Doppler project role.
 ---

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secret Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Secrets"
 description: |-
 	Manage a single Doppler secret in a config.
 ---

--- a/docs/resources/secrets_sync_aws_parameter_store.md
+++ b/docs/resources/secrets_sync_aws_parameter_store.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_aws_parameter_store Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an AWS Parameter Store Doppler sync.
 ---

--- a/docs/resources/secrets_sync_aws_secrets_manager.md
+++ b/docs/resources/secrets_sync_aws_secrets_manager.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_aws_secrets_manager Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an AWS Secrets Manager Doppler sync.
 ---

--- a/docs/resources/secrets_sync_azure_vault.md
+++ b/docs/resources/secrets_sync_azure_vault.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_azure_vault Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an Azure Vault Doppler sync.
 ---

--- a/docs/resources/secrets_sync_circleci.md
+++ b/docs/resources/secrets_sync_circleci.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_circleci Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a CircleCI Doppler sync.
 ---

--- a/docs/resources/secrets_sync_flyio.md
+++ b/docs/resources/secrets_sync_flyio.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_flyio Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a Fly.io Doppler sync.
 ---

--- a/docs/resources/secrets_sync_gcp_secret_manager.md
+++ b/docs/resources/secrets_sync_gcp_secret_manager.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_gcp_secret_manager Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a GCP Secret Manager Doppler sync.
 ---

--- a/docs/resources/secrets_sync_github_actions.md
+++ b/docs/resources/secrets_sync_github_actions.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_github_actions Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a GitHub Actions Doppler sync.
 ---

--- a/docs/resources/secrets_sync_terraform_cloud.md
+++ b/docs/resources/secrets_sync_terraform_cloud.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_terraform_cloud Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a Terraform Cloud Doppler sync.
 ---

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_service_account Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Service Accounts"
 description: |-
 	Manage a Doppler service account.
 ---

--- a/docs/resources/service_account_token.md
+++ b/docs/resources/service_account_token.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_service_account_token Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Service Accounts"
 description: |-
 	Manage a Doppler service_account_token.
 ---

--- a/docs/resources/service_token.md
+++ b/docs/resources/service_token.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_service_token Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Service Tokens"
 description: |-
 	Manage a Doppler service_token.
 ---

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_webhook Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Webhooks"
 description: |-
 	Manage a Doppler Webhook.
 ---

--- a/docs/resources/workplace_role.md
+++ b/docs/resources/workplace_role.md
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_workplace_role Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Roles"
 description: |-
 	Manage a Doppler workplace role.
 ---

--- a/templates/data-sources/group.md.tmpl
+++ b/templates/data-sources/group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_group Data Source - terraform-provider-doppler"
-subcategory: "Group"
+subcategory: "Groups"
 description: |-
   Retrieve an existing Doppler group.
 ---

--- a/templates/data-sources/user.md.tmpl
+++ b/templates/data-sources/user.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_user Data Source - terraform-provider-doppler"
-subcategory: "User"
+subcategory: "Users"
 description: |-
   Retrieve an existing Doppler user.
 ---

--- a/templates/resources/change_request_policy.md.tmpl
+++ b/templates/resources/change_request_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_change_request_policy Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Change Requests"
 description: |-
 	Manage a Doppler change request policy.
 ---

--- a/templates/resources/config.md.tmpl
+++ b/templates/resources/config.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_config Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Project Structure"
 description: |-
 	Manage a Doppler config.
 ---

--- a/templates/resources/environment.md.tmpl
+++ b/templates/resources/environment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_environment Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Project Structure"
 description: |-
 	Manage a Doppler environment.
 ---

--- a/templates/resources/group.md.tmpl
+++ b/templates/resources/group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_group Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Groups"
 description: |-
 	Manage a Doppler group.
 ---

--- a/templates/resources/group_member.md.tmpl
+++ b/templates/resources/group_member.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_group_member Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Groups"
 description: |-
 	Manage a Doppler user/group membership.
 ---

--- a/templates/resources/group_members.md.tmpl
+++ b/templates/resources/group_members.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_group_members Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Groups"
 description: |-
 	Manage a Doppler group's memberships.
 ---

--- a/templates/resources/integration_aws_parameter_store.md.tmpl
+++ b/templates/resources/integration_aws_parameter_store.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_aws_parameter_store Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an AWS Parameter Store Doppler integration.
 ---

--- a/templates/resources/integration_aws_secrets_manager.md.tmpl
+++ b/templates/resources/integration_aws_secrets_manager.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_aws_secrets_manager Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an AWS Secrets Manager Doppler integration.
 ---

--- a/templates/resources/integration_azure_vault_service_principal.md.tmpl
+++ b/templates/resources/integration_azure_vault_service_principal.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_azure_vault_service_principal Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an Azure Vault (Service Principal) Doppler integration.
 ---

--- a/templates/resources/integration_circleci.md.tmpl
+++ b/templates/resources/integration_circleci.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_circleci Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a CircleCI Doppler integration.
 ---

--- a/templates/resources/integration_flyio.md.tmpl
+++ b/templates/resources/integration_flyio.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_flyio Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a Fly.io Doppler integration.
 ---

--- a/templates/resources/integration_gcp_secret_manager.md.tmpl
+++ b/templates/resources/integration_gcp_secret_manager.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_gcp_secret_manager Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a GCP Secret Manager Doppler integration.
 ---

--- a/templates/resources/integration_terraform_cloud.md.tmpl
+++ b/templates/resources/integration_terraform_cloud.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_integration_terraform_cloud Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a Terraform Cloud Doppler integration.
 ---

--- a/templates/resources/project.md.tmpl
+++ b/templates/resources/project.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_project Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Project Structure"
 description: |-
 	Manage a Doppler project.
 ---

--- a/templates/resources/project_member_group.md.tmpl
+++ b/templates/resources/project_member_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_project_member_group Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Project Structure"
 description: |-
 	Manage a Doppler project group member.
 ---

--- a/templates/resources/project_member_service_account.md.tmpl
+++ b/templates/resources/project_member_service_account.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_project_member_service_account Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Project Structure"
 description: |-
 	Manage a Doppler project service account member.
 ---

--- a/templates/resources/project_role.md.tmpl
+++ b/templates/resources/project_role.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_project_role Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Roles"
 description: |-
 	Manage a Doppler project role.
 ---

--- a/templates/resources/secret.md.tmpl
+++ b/templates/resources/secret.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secret Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Secrets"
 description: |-
 	Manage a single Doppler secret in a config.
 ---

--- a/templates/resources/secrets_sync_aws_parameter_store.md.tmpl
+++ b/templates/resources/secrets_sync_aws_parameter_store.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_aws_parameter_store Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an AWS Parameter Store Doppler sync.
 ---

--- a/templates/resources/secrets_sync_aws_secrets_manager.md.tmpl
+++ b/templates/resources/secrets_sync_aws_secrets_manager.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_aws_secrets_manager Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an AWS Secrets Manager Doppler sync.
 ---

--- a/templates/resources/secrets_sync_azure_vault.md.tmpl
+++ b/templates/resources/secrets_sync_azure_vault.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_azure_vault Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage an Azure Vault Doppler sync.
 ---

--- a/templates/resources/secrets_sync_circleci.md.tmpl
+++ b/templates/resources/secrets_sync_circleci.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_circleci Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a CircleCI Doppler sync.
 ---

--- a/templates/resources/secrets_sync_flyio.md.tmpl
+++ b/templates/resources/secrets_sync_flyio.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_flyio Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a Fly.io Doppler sync.
 ---

--- a/templates/resources/secrets_sync_gcp_secret_manager.md.tmpl
+++ b/templates/resources/secrets_sync_gcp_secret_manager.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_gcp_secret_manager Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a GCP Secret Manager Doppler sync.
 ---

--- a/templates/resources/secrets_sync_github_actions.md.tmpl
+++ b/templates/resources/secrets_sync_github_actions.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_github_actions Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a GitHub Actions Doppler sync.
 ---

--- a/templates/resources/secrets_sync_terraform_cloud.md.tmpl
+++ b/templates/resources/secrets_sync_terraform_cloud.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_secrets_sync_terraform_cloud Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Integrations"
 description: |-
 	Manage a Terraform Cloud Doppler sync.
 ---

--- a/templates/resources/service_account.md.tmpl
+++ b/templates/resources/service_account.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_service_account Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Service Accounts"
 description: |-
 	Manage a Doppler service account.
 ---

--- a/templates/resources/service_account_token.md.tmpl
+++ b/templates/resources/service_account_token.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_service_account_token Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Service Accounts"
 description: |-
 	Manage a Doppler service_account_token.
 ---

--- a/templates/resources/service_token.md.tmpl
+++ b/templates/resources/service_token.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_service_token Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Service Tokens"
 description: |-
 	Manage a Doppler service_token.
 ---

--- a/templates/resources/webhook.md.tmpl
+++ b/templates/resources/webhook.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_webhook Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Webhooks"
 description: |-
 	Manage a Doppler Webhook.
 ---

--- a/templates/resources/workplace_role.md.tmpl
+++ b/templates/resources/workplace_role.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "doppler_workplace_role Resource - terraform-provider-doppler"
-subcategory: ""
+subcategory: "Roles"
 description: |-
 	Manage a Doppler workplace role.
 ---


### PR DESCRIPTION
I noticed that these end up getting rendered as nice subheaders in the [Terraform registry](https://registry.terraform.io/providers/DopplerHQ/doppler/latest/docs). Most of ours are empty strings today so they're all nested at the top level under "Resources" (shown collapsed here):

<img width="765" alt="Screenshot 2025-04-29 at 10 32 22 AM" src="https://github.com/user-attachments/assets/f7d9c264-6415-4bd1-a3f5-3e7913547ef3" />

This PR adds better subcategories, hopefully making data sources and resources easier to find and discover.