### PR TITLE
Handle secret in TF state missing in Doppler

### DIFF
--- a/doppler/api.go
+++ b/doppler/api.go
@@ -237,6 +237,14 @@ func (client APIClient) GetSecret(ctx context.Context, project string, config st
 	if err := json.Unmarshal(response.Body, &result); err != nil {
 		return nil, &APIError{Err: err, Message: "Unable to parse secret"}
 	}
+	if result.Value.Raw == nil &&
+		result.Value.Computed == nil &&
+		result.Value.RawVisibility == nil &&
+		result.Value.ComputedVisibility == nil &&
+		result.Value.RawValueType == nil &&
+		result.Value.ComputedValueType == nil {
+		return nil, &CustomNotFoundError{Message: "Secret does not exist"}
+	}
 	return &result, nil
 }
 


### PR DESCRIPTION
When fetching secrets from this specific endpoint, all properties of `value` will be null if the secret is not found. Return a not found error instead of the response data in this case.

Fixes https://github.com/DopplerHQ/terraform-provider-doppler/issues/115 https://github.com/DopplerHQ/terraform-provider-doppler/issues/136