### PR TITLE
Allow renaming integrations via TF provider

### DIFF
--- a/doppler/resource_integration.go
+++ b/doppler/resource_integration.go
@@ -22,7 +22,6 @@ func (builder ResourceIntegrationBuilder) Build() *schema.Resource {
 			Description: "The name of the integration",
 			Type:        schema.TypeString,
 			Required:    true,
-			ForceNew:    true,
 		},
 	}
 


### PR DESCRIPTION
This removes the ForceNew parameter from Integration names, allowing for non-destructive updates. Thanks for pointing this out, @apazzolini !

Closes: ENG-8971