### PR TITLE
Add sync_unmasked_as_variables to GitHub Actions resource

### DIFF
--- a/docs/resources/secrets_sync_github_actions.md
+++ b/docs/resources/secrets_sync_github_actions.md
@@ -33,6 +33,17 @@ resource "doppler_secrets_sync_github_actions" "backend_prod" {
   environment_name = "production"
 }
 
+# Repo + Variable Syncing
+resource "doppler_secrets_sync_github_actions" "backend_prod" {
+  integration = "bae40485-eca7-478b-abd8-34100c82c679"
+  project     = "backend"
+  config      = "prd"
+
+  sync_target                = "repo"
+  repo_name                  = "backend"
+  sync_unmasked_as_variables = true
+}
+
 # Org
 resource "doppler_secrets_sync_github_actions" "backend_prod" {
   integration = "bae40485-eca7-478b-abd8-34100c82c679"
@@ -60,6 +71,7 @@ resource "doppler_secrets_sync_github_actions" "backend_prod" {
 - `environment_name` (String) The GitHub repo environment name to sync to (only used when `sync_target` is set to "repo")
 - `org_scope` (String) Either "all" or "private", based on the which repos you want to have access (only used when `sync_target` is set to "org")
 - `repo_name` (String) The GitHub repo name to sync to (only used when `sync_target` is set to "repo")
+- `sync_unmasked_as_variables` (Boolean) When enabled, causes secrets with the `unmasked` visibility type to get synced as GitHub Action Variables. Defaults to `false`.
 
 ### Read-Only
 

--- a/doppler/resource_sync_types.go
+++ b/doppler/resource_sync_types.go
@@ -330,6 +330,13 @@ func resourceSyncGitHubActions() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 			},
+			"sync_unmasked_as_variables": {
+				Description: "When enabled, causes secrets with the `unmasked` visibility type to get synced as GitHub Action Variables. Defaults to `false`.",
+				Type:        schema.TypeBool,
+				Default:     false,
+				Optional:    true,
+				ForceNew:    true,
+			},
 		},
 		DataBuilder: func(d *schema.ResourceData) IntegrationData {
 			payload := map[string]interface{}{
@@ -347,6 +354,10 @@ func resourceSyncGitHubActions() *schema.Resource {
 			environment_name := d.Get("environment_name")
 			if environment_name != "" {
 				payload["environment_name"] = environment_name
+			}
+			sync_unmasked_as_variables := d.Get("sync_unmasked_as_variables")
+			if sync_unmasked_as_variables != "" {
+				payload["sync_unmasked_as_variables"] = sync_unmasked_as_variables
 			}
 			return payload
 		},

--- a/examples/resources/secrets_sync_github_actions.tf
+++ b/examples/resources/secrets_sync_github_actions.tf
@@ -19,6 +19,17 @@ resource "doppler_secrets_sync_github_actions" "backend_prod" {
   environment_name = "production"
 }
 
+# Repo + Variable Syncing
+resource "doppler_secrets_sync_github_actions" "backend_prod" {
+  integration = "bae40485-eca7-478b-abd8-34100c82c679"
+  project     = "backend"
+  config      = "prd"
+
+  sync_target                = "repo"
+  repo_name                  = "backend"
+  sync_unmasked_as_variables = true
+}
+
 # Org
 resource "doppler_secrets_sync_github_actions" "backend_prod" {
   integration = "bae40485-eca7-478b-abd8-34100c82c679"


### PR DESCRIPTION
This adds support for the new option that lets you sync secrets with the `unmasked` visibility type in Doppler to GitHub Actions as a GitHub Actions Variable rather than a GitHub Actions Secret.

Fixes ENG-9000