### PR TITLE
Improve docs for `doppler_secret` resource

### DIFF
--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -44,7 +44,7 @@ output "resource_value" {
 ### Optional
 
 - `value_type` (String) The value type of the secret
-- `visibility` (String) The visibility of the secret
+- `visibility` (String) The visibility of the secret. One of `masked`, `unmasked`, or `restricted`. Defaults to `masked`.
 
 ### Read-Only
 

--- a/doppler/resource_secret.go
+++ b/doppler/resource_secret.go
@@ -47,7 +47,7 @@ func resourceSecret() *schema.Resource {
 				Sensitive:   true,
 			},
 			"visibility": {
-				Description:  "The visibility of the secret",
+				Description:  "The visibility of the secret. One of `masked`, `unmasked`, or `restricted`. Defaults to `masked`.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "masked",


### PR DESCRIPTION
The docs for `doppler_secret` didn't explain what the options for `visibility` were. This improves those docs by listing the possible options and noting what the default value is.