### PR TITLE
feat: add expire_at to doppler_service_token

### DIFF
--- a/docs/resources/service_token.md
+++ b/docs/resources/service_token.md
@@ -34,6 +34,7 @@ resource "doppler_service_token" "backend_ci_token" {
 ### Optional
 
 - `access` (String) The access level (read or read/write)
+- `expire_at` (String) The expiration time of the token as an RFC3339 timestamp (e.g. `2026-12-31T23:59:59Z`). If omitted, the token never expires.
 
 ### Read-Only
 

--- a/doppler/api.go
+++ b/doppler/api.go
@@ -1177,12 +1177,15 @@ func (client APIClient) GetServiceTokens(ctx context.Context, project string, co
 	return result.ServiceTokens, nil
 }
 
-func (client APIClient) CreateServiceToken(ctx context.Context, project string, config string, access string, name string) (*ServiceToken, error) {
+func (client APIClient) CreateServiceToken(ctx context.Context, project string, config string, access string, name string, expireAt string) (*ServiceToken, error) {
 	payload := map[string]interface{}{
 		"project": project,
 		"config":  config,
 		"access":  access,
 		"name":    name,
+	}
+	if expireAt != "" {
+		payload["expire_at"] = expireAt
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/doppler/models.go
+++ b/doppler/models.go
@@ -274,6 +274,7 @@ type ServiceToken struct {
 	Access      string `json:"access"`
 	Key         string `json:"key"`
 	CreatedAt   string `json:"created_at"`
+	ExpiresAt   string `json:"expires_at,omitempty"`
 }
 
 type ServiceTokenResponse struct {

--- a/doppler/resource_service_token.go
+++ b/doppler/resource_service_token.go
@@ -42,6 +42,13 @@ func resourceServiceToken() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"read", "read/write"}, false),
 				ForceNew:     true,
 			},
+			"expire_at": {
+				Description:  "The expiration time of the token as an RFC3339 timestamp (e.g. `2026-12-31T23:59:59Z`). If omitted, the token never expires.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsRFC3339Time,
+			},
 			"key": {
 				Description: "The key for the Doppler service token",
 				Type:        schema.TypeString,
@@ -60,8 +67,9 @@ func resourceServiceTokenCreate(ctx context.Context, d *schema.ResourceData, m i
 	config := d.Get("config").(string)
 	access := d.Get("access").(string)
 	name := d.Get("name").(string)
+	expireAt := d.Get("expire_at").(string)
 
-	token, err := client.CreateServiceToken(ctx, project, config, access, name)
+	token, err := client.CreateServiceToken(ctx, project, config, access, name, expireAt)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
## TL;DR

Adds an optional `expire_at` argument to `doppler_service_token` so authors can declare token expiration in IaC. The Doppler API already accepts `expire_at` on token create; the provider just wasn't exposing it. Closes [#62](https://github.com/DopplerHQ/terraform-provider-doppler/issues/62).

## Why

`doppler_service_token` currently produces tokens that live forever until manually revoked. The Doppler API has supported an optional `expire_at` (RFC3339 timestamp) on `POST /v3/configs/config/tokens` for some time, but the provider never wired it through. This forces operators to either trust never-expiring service tokens or build out-of-band rotation tooling. Neither is great when the IaC repo is the canonical owner of those tokens.

## Implementation

- `expire_at` is an Optional, ForceNew string field validated as RFC3339. ForceNew because the Doppler API has no update path for token expiration; rotation requires a new token.
- The new arg is conditionally added to the create payload only when non-empty, so existing token resources without `expire_at` continue to call the API exactly as before.
- `ServiceToken.ExpiresAt` is captured from the response (`json:"expires_at,omitempty"`) for completeness, though the Read function does not currently set it back on state. The asymmetric API naming (`expire_at` on request, `expires_at` on response) means refreshing it could mask user-input drift; deferring that decision since the field is ForceNew anyway.

## Links

- Issue: [#62](https://github.com/DopplerHQ/terraform-provider-doppler/issues/62)
- Original CoreWeave comment: [#62 comment](https://github.com/DopplerHQ/terraform-provider-doppler/issues/62#issuecomment-4530014671)